### PR TITLE
Fix README links, sequential-run path, and test quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ features:
 - Optimize graphs
 
 This means the AI ​​cleans up your graph and creates stronger connections at the edges, shifting memories between STM, MTM, and LTM.
-You can find more detailed information in /Jarvis/maintenance README.md
+You can find more detailed information in /maintenance/README.md
 
 <img width="671" height="615" alt="Bildschirmfoto 2026-01-04 um 18 53 22" src="https://github.com/user-attachments/assets/59d64fa4-da57-4452-b619-b00bc310b42e" />
 

--- a/Sequential Thinking/README.md
+++ b/Sequential Thinking/README.md
@@ -27,6 +27,6 @@ A `Dockerfile` and `docker-compose.yaml` are provided to run this service in a c
 
 ### Running Manually
 ```bash
-python Sequential-thinking.py
+python mcp-sequential/Sequential-thinking.py
 ```
 **Note**: Runs on port 8085 by default.

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -89,11 +89,11 @@ sudo docker compose restart lobechat-adapter
 **Solution**: Implemented memory_list_conversations tool  
 **Result**: Now finds 5 conversations, 48 entries, 40 nodes
 
-See: [DEBUGGING_LOG.md](/assistant-proxy/DEBUGGING_LOG.md)
+See: [DEBUGGING_LOG.md](/DEBUGGING_LOG.md)
 
 ---
 
 ## References
 - [Core Architecture](/documentation/01_CORE.md)
 - [MCP Documentation](/documentation/03_MCP.md)  
-- [Debugging Log](/assistant-proxy/DEBUGGING_LOG.md)
+- [Debugging Log](/DEBUGGING_LOG.md)

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,8 @@
 
 ```bash
 # Dependencies installieren
-pip install -r requirements-dev.txt
+pip install -r requirements.txt
+pip install pytest pytest-cov
 
 # Alle Tests ausführen
 pytest


### PR DESCRIPTION
### Motivation
- Fix incorrect documentation links that pointed to outdated paths for the maintenance/debugging log. 
- Ensure the Sequential Thinking manual run command references the actual subdirectory path. 
- Make the tests quick-start accurate and include `pytest` tooling so contributors can run tests locally.

### Description
- Updated the root `README.md` link to point to `/maintenance/README.md`. 
- Replaced debugging log links in `maintenance/README.md` to reference `/DEBUGGING_LOG.md`. 
- Corrected the manual run command in `Sequential Thinking/README.md` to `python mcp-sequential/Sequential-thinking.py`. 
- Updated `tests/README.md` to install dependencies from `requirements.txt` and added `pip install pytest pytest-cov` to the quick-start.

### Testing
- No automated tests were executed because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968ef530a68832e8feb8253b3c4e0c0)