### PR TITLE
Task-loop: Persistiere Container-Systemzustand im Snapshot und übergebe vollständigen Thinking-Plan an Step-Context

### DIFF
--- a/core/task_loop/capabilities/container/context.py
+++ b/core/task_loop/capabilities/container/context.py
@@ -53,6 +53,25 @@ def _python_requested(user_text: str, intent: str, existing_context: Dict[str, A
     )
 
 
+def _active_container_known_fields(source: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(source, dict):
+        return {}
+    ctx = source.get("_active_container_capability_context")
+    if not isinstance(ctx, dict):
+        return {}
+    known: Dict[str, Any] = {}
+    container_id = str(ctx.get("container_id") or "").strip()
+    blueprint_id = str(ctx.get("blueprint_id") or "").strip()
+    image = str(ctx.get("image") or "").strip()
+    if container_id:
+        known["container_id"] = container_id
+    if blueprint_id:
+        known["blueprint"] = blueprint_id
+    if image:
+        known["image"] = image
+    return known
+
+
 def build_container_context(
     user_text: str,
     *,
@@ -67,6 +86,7 @@ def build_container_context(
 
     context = dict(existing_context or {})
     known_fields = dict(context.get("known_fields") or {})
+    known_fields.update(_active_container_known_fields(plan))
     known_fields.update(extract_container_capability_fields_from_text(user_text))
     intent = str(plan.get("intent") or "").strip()
     python_requested = _python_requested(user_text, intent, context)
@@ -91,6 +111,7 @@ def merge_container_context(
     if snapshot is not None:
         snapshot_context = extract_container_context(snapshot)
         known_fields.update(dict(snapshot_context.get("known_fields") or {}))
+        known_fields.update(_active_container_known_fields(dict(snapshot.system_state or {})))
         for artifact in reversed(list(snapshot.verified_artifacts or [])):
             if not isinstance(artifact, dict):
                 continue

--- a/core/task_loop/contracts.py
+++ b/core/task_loop/contracts.py
@@ -283,6 +283,7 @@ class TaskLoopSnapshot:
     error_count: int = 0
     no_progress_count: int = 0
     objective_summary: str = ""
+    system_state: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -309,6 +310,7 @@ class TaskLoopSnapshot:
             "error_count": int(self.error_count),
             "no_progress_count": int(self.no_progress_count),
             "objective_summary": self.objective_summary,
+            "system_state": dict(self.system_state),
         }
 
 

--- a/core/task_loop/planner/snapshots.py
+++ b/core/task_loop/planner/snapshots.py
@@ -14,6 +14,21 @@ from core.task_loop.planner.objective import clean_task_loop_objective
 from core.task_loop.planner.steps import build_task_loop_steps
 
 
+def _snapshot_system_state(thinking_plan: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    plan = thinking_plan if isinstance(thinking_plan, dict) else {}
+    state: Dict[str, Any] = {}
+    for key in (
+        "_active_container_capability_context",
+        "_container_capability_context",
+        "_global_active_containers",
+        "active_containers_context",
+    ):
+        value = plan.get(key)
+        if isinstance(value, (dict, list)):
+            state[key] = value
+    return state
+
+
 def create_task_loop_snapshot_from_plan(
     user_text: str,
     conversation_id: str,
@@ -40,6 +55,7 @@ def create_task_loop_snapshot_from_plan(
         pending_step=first,
         risk_level=RiskLevel.SAFE,
         objective_summary=objective_summary,
+        system_state=_snapshot_system_state(thinking_plan),
     )
 
 

--- a/core/task_loop/planner/steps.py
+++ b/core/task_loop/planner/steps.py
@@ -62,6 +62,7 @@ def _base_steps_for_kind(
     risk_level: RiskLevel,
     suggested_tools: List[str],
     capability_context: Optional[Dict[str, Any]] = None,
+    thinking_plan: Optional[Dict[str, Any]] = None,
 ) -> List[TaskLoopStep]:
     focus = _clip(intent, 120)
     objective_text = _keyword_text(objective)
@@ -75,7 +76,7 @@ def _base_steps_for_kind(
     if capability_type_from_tools(suggested_tools) == "container_manager":
         container_capability_context = build_container_context(
             user_text,
-            thinking_plan={"intent": intent, "suggested_tools": suggested_tools},
+            thinking_plan=thinking_plan or {"intent": intent, "suggested_tools": suggested_tools},
             selected_tools=suggested_tools,
             existing_context=capability_context,
         )
@@ -297,6 +298,7 @@ def build_task_loop_steps(
         risk_level=risk_level,
         suggested_tools=suggested_tools,
         capability_context=capability_context if isinstance(capability_context, dict) else None,
+        thinking_plan=plan,
     )
 
     if reasoning:


### PR DESCRIPTION
### Motivation
- Der Task-Loop verlor zur Laufzeit relevante Container-Identität/Context beim Erzeugen von Snapshots und beim Erstellen von Steps, was zu fehlerhaften oder halluzinierten Container-Aktionen führte.
- Snapshot-Objekte enthielten bisher keine „live world state“-Dimension, so dass Plan-/Runner-Übergänge wichtige Felder wie `_active_container_capability_context` oder `_global_active_containers` verworfen haben.
- Ziel der Änderung ist, den containerbezogenen Weltzustand durch die Plan-/Snapshot-Übergänge zu erhalten und beim Erzeugen von Container-Kontexten wieder zur Verfügung zu stellen.

### Description
- `TaskLoopSnapshot` erweitert um das Feld `system_state: Dict[str, Any]` und dieses Feld wird in `to_dict()` serialisiert (`core/task_loop/contracts.py`).
- Beim Snapshot-Bau (`create_task_loop_snapshot_from_plan`) werden ausgewählte plan-/container-relevante Keys (`_active_container_capability_context`, `_container_capability_context`, `_global_active_containers`, `active_containers_context`) in `system_state` übernommen (`core/task_loop/planner/snapshots.py`).
- Die Step-Erzeugung übergibt jetzt den vollständigen `thinking_plan` an die Container-Context-Build-Logik statt nur eines amputierten Teils (`core/task_loop/planner/steps.py`).
- Die Container-Context-Funktionen holen nun aktive Container-Hinweise (`container_id`, `blueprint`, `image`) sowohl direkt aus dem `thinking_plan` als auch aus `snapshot.system_state` beim Mergen von Kontextelementen (`core/task_loop/capabilities/container/context.py`).

### Testing
- Automatischer Kompilier-Check `python -m compileall core/task_loop/contracts.py core/task_loop/planner/snapshots.py core/task_loop/planner/steps.py core/task_loop/capabilities/container/context.py` wurde ausgeführt und hat erfolgreich kompiliert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed5eb568c832ebb97f46fed903325)