### PR TITLE
Persist TaskLoop system_state and propagate active-container context to planning

### DIFF
--- a/core/orchestrator_modules/task_loop.py
+++ b/core/orchestrator_modules/task_loop.py
@@ -258,6 +258,7 @@ async def maybe_handle_task_loop_sync(
         thinking_plan = await build_task_loop_planning_context(
             orch,
             user_text,
+            conversation_id=conversation_id,
             request=request,
             tone_signal=tone_signal,
             log_info_fn=log_info_fn,
@@ -329,6 +330,7 @@ async def maybe_build_task_loop_stream_events(
         thinking_plan = await build_task_loop_planning_context(
             orch,
             user_text,
+            conversation_id=conversation_id,
             request=request,
             tone_signal=tone_signal,
             log_info_fn=log_info_fn,
@@ -550,6 +552,7 @@ async def stream_task_loop_events(
         effective_plan = await build_task_loop_planning_context(
             orch,
             user_text,
+            conversation_id=conversation_id,
             request=request,
             tone_signal=tone_signal,
             log_info_fn=log_info_fn,

--- a/core/task_loop/capabilities/container/context.py
+++ b/core/task_loop/capabilities/container/context.py
@@ -53,6 +53,25 @@ def _python_requested(user_text: str, intent: str, existing_context: Dict[str, A
     )
 
 
+def _active_container_known_fields(source: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(source, dict):
+        return {}
+    ctx = source.get("_active_container_capability_context")
+    if not isinstance(ctx, dict):
+        return {}
+    known: Dict[str, Any] = {}
+    container_id = str(ctx.get("container_id") or "").strip()
+    blueprint_id = str(ctx.get("blueprint_id") or "").strip()
+    image = str(ctx.get("image") or "").strip()
+    if container_id:
+        known["container_id"] = container_id
+    if blueprint_id:
+        known["blueprint"] = blueprint_id
+    if image:
+        known["image"] = image
+    return known
+
+
 def build_container_context(
     user_text: str,
     *,
@@ -67,6 +86,7 @@ def build_container_context(
 
     context = dict(existing_context or {})
     known_fields = dict(context.get("known_fields") or {})
+    known_fields.update(_active_container_known_fields(plan))
     known_fields.update(extract_container_capability_fields_from_text(user_text))
     intent = str(plan.get("intent") or "").strip()
     python_requested = _python_requested(user_text, intent, context)
@@ -91,6 +111,7 @@ def merge_container_context(
     if snapshot is not None:
         snapshot_context = extract_container_context(snapshot)
         known_fields.update(dict(snapshot_context.get("known_fields") or {}))
+        known_fields.update(_active_container_known_fields(dict(snapshot.system_state or {})))
         for artifact in reversed(list(snapshot.verified_artifacts or [])):
             if not isinstance(artifact, dict):
                 continue

--- a/core/task_loop/contracts.py
+++ b/core/task_loop/contracts.py
@@ -283,6 +283,7 @@ class TaskLoopSnapshot:
     error_count: int = 0
     no_progress_count: int = 0
     objective_summary: str = ""
+    system_state: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -309,6 +310,7 @@ class TaskLoopSnapshot:
             "error_count": int(self.error_count),
             "no_progress_count": int(self.no_progress_count),
             "objective_summary": self.objective_summary,
+            "system_state": dict(self.system_state),
         }
 
 

--- a/core/task_loop/pipeline_adapter.py
+++ b/core/task_loop/pipeline_adapter.py
@@ -12,6 +12,7 @@ async def build_task_loop_planning_context(
     orch: Any,
     user_text: str,
     *,
+    conversation_id: str = "",
     request: Any = None,
     forced_response_mode: Optional[str] = None,
     tone_signal: Optional[Dict[str, Any]] = None,
@@ -86,6 +87,24 @@ async def build_task_loop_planning_context(
                 user_text=user_text,
                 selected_tools=selected_tools,
             )
+        maybe_active_container_ctx = getattr(orch, "_maybe_build_active_container_capability_context", None)
+        if (
+            isinstance(plan, dict)
+            and callable(maybe_active_container_ctx)
+            and str(conversation_id or "").strip()
+        ):
+            try:
+                await maybe_active_container_ctx(
+                    user_text=user_text,
+                    conversation_id=str(conversation_id or "").strip(),
+                    verified_plan=plan,
+                )
+            except Exception as exc:
+                if log_warn_fn:
+                    log_warn_fn(
+                        "[TaskLoop] Active-container context for planning context skipped: "
+                        f"{exc}"
+                    )
         if (
             isinstance(plan, dict)
             and not plan.get("suggested_tools")

--- a/core/task_loop/planner/snapshots.py
+++ b/core/task_loop/planner/snapshots.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from hashlib import sha256
 from typing import Any, Dict, Optional
 
@@ -12,6 +13,21 @@ from core.task_loop.contracts import (
 )
 from core.task_loop.planner.objective import clean_task_loop_objective
 from core.task_loop.planner.steps import build_task_loop_steps
+
+
+def _snapshot_system_state(thinking_plan: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    plan = thinking_plan if isinstance(thinking_plan, dict) else {}
+    state: Dict[str, Any] = {}
+    for key in (
+        "_active_container_capability_context",
+        "_container_capability_context",
+        "_global_active_containers",
+        "active_containers_context",
+    ):
+        value = plan.get(key)
+        if isinstance(value, (dict, list)):
+            state[key] = deepcopy(value)
+    return state
 
 
 def create_task_loop_snapshot_from_plan(
@@ -40,6 +56,7 @@ def create_task_loop_snapshot_from_plan(
         pending_step=first,
         risk_level=RiskLevel.SAFE,
         objective_summary=objective_summary,
+        system_state=_snapshot_system_state(thinking_plan),
     )
 
 

--- a/core/task_loop/planner/steps.py
+++ b/core/task_loop/planner/steps.py
@@ -62,6 +62,7 @@ def _base_steps_for_kind(
     risk_level: RiskLevel,
     suggested_tools: List[str],
     capability_context: Optional[Dict[str, Any]] = None,
+    thinking_plan: Optional[Dict[str, Any]] = None,
 ) -> List[TaskLoopStep]:
     focus = _clip(intent, 120)
     objective_text = _keyword_text(objective)
@@ -75,7 +76,7 @@ def _base_steps_for_kind(
     if capability_type_from_tools(suggested_tools) == "container_manager":
         container_capability_context = build_container_context(
             user_text,
-            thinking_plan={"intent": intent, "suggested_tools": suggested_tools},
+            thinking_plan=thinking_plan or {"intent": intent, "suggested_tools": suggested_tools},
             selected_tools=suggested_tools,
             existing_context=capability_context,
         )
@@ -297,6 +298,7 @@ def build_task_loop_steps(
         risk_level=risk_level,
         suggested_tools=suggested_tools,
         capability_context=capability_context if isinstance(capability_context, dict) else None,
+        thinking_plan=plan,
     )
 
     if reasoning:


### PR DESCRIPTION
### Motivation

- Preserve active/container-related context discovered during thinking so subsequent task-loop execution and container steps can access it.
- Ensure the planning stage can build or update an active-container capability context when a conversation id is available.
- Improve container capability context merging so known active container fields are considered when building blueprints and merging snapshot state.

### Description

- Pass `conversation_id` into `build_task_loop_planning_context` calls in `core/orchestrator_modules/task_loop.py` so planning can be aware of the conversation when invoked from sync and stream flows.  
- Extend `build_task_loop_planning_context` signature in `core/task_loop/pipeline_adapter.py` to accept `conversation_id` and call `orch._maybe_build_active_container_capability_context` when available, with exception handling and warning logs.  
- Add a `system_state: Dict[str, Any]` field to `TaskLoopSnapshot` in `core/task_loop/contracts.py` and include it in `to_dict`.  
- Capture a snapshot of relevant plan-level keys into `system_state` via `_snapshot_system_state` and set it when creating snapshots in `core/task_loop/planner/snapshots.py`.  
- Thread `thinking_plan` into planner step creation in `core/task_loop/planner/steps.py` so container step blueprints receive the full plan context.  
- Add `_active_container_known_fields` in `core/task_loop/capabilities/container/context.py` and use it to seed `known_fields` in both `build_container_context` and `merge_container_context`, and update merging to pull active container info from `snapshot.system_state`.

### Testing

- Ran the repository's task-loop and container-capability unit tests; the tests completed successfully.  
- Ran the code path smoke checks for sync and streaming task-loop planning flows; they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed5eb568c832ebb97f46fed903325)